### PR TITLE
Fix: 아티스트 페이지

### DIFF
--- a/client/src/pages/artist/Artist.tsx
+++ b/client/src/pages/artist/Artist.tsx
@@ -81,12 +81,14 @@ export default function Artistpage() {
             <S.EmptyContainer>
               <S.EmptyWrapper>
                 <S.EmptyTitle>준비중인 공연이 없습니다.</S.EmptyTitle>
-                <ConcertEmptyButton>
-                  <ButtonWithArrowDark
-                    onClick={() => navigate('/performances/register')}
-                    text="공연등록"
-                  ></ButtonWithArrowDark>
-                </ConcertEmptyButton>
+                {artistId === getCookie('userInfo')?.artistId && (
+                  <ConcertEmptyButton>
+                    <ButtonWithArrowDark
+                      onClick={() => navigate('/performances/register')}
+                      text="공연등록"
+                    ></ButtonWithArrowDark>
+                  </ConcertEmptyButton>
+                )}
               </S.EmptyWrapper>
             </S.EmptyContainer>
           )}
@@ -110,12 +112,14 @@ export default function Artistpage() {
               <S.EmptyContainer>
                 <S.EmptyWrapper>
                   <S.EmptyTitle>완료한 공연이 없습니다.</S.EmptyTitle>
-                  <ConcertEmptyButton>
-                    <ButtonWithArrowDark
-                      onClick={() => navigate('/performances/register')}
-                      text="공연등록"
-                    ></ButtonWithArrowDark>
-                  </ConcertEmptyButton>
+                  {artistId === getCookie('userInfo')?.artistId && (
+                    <ConcertEmptyButton>
+                      <ButtonWithArrowDark
+                        onClick={() => navigate('/performances/register')}
+                        text="공연등록"
+                      ></ButtonWithArrowDark>
+                    </ConcertEmptyButton>
+                  )}
                 </S.EmptyWrapper>
               </S.EmptyContainer>
             )}
@@ -135,17 +139,18 @@ export default function Artistpage() {
               <S.EmptyContainer>
                 <S.EmptyWrapper>
                   <S.EmptyTitle>완료한 공연이 없습니다.</S.EmptyTitle>
-                  <ConcertEmptyButton>
-                    <ButtonWithArrowDark
-                      onClick={() => navigate('/performances/register')}
-                      text="공연등록"
-                    ></ButtonWithArrowDark>
-                  </ConcertEmptyButton>
+                  {artistId === getCookie('userInfo')?.artistId && (
+                    <ConcertEmptyButton>
+                      <ButtonWithArrowDark
+                        onClick={() => navigate('/performances/register')}
+                        text="공연등록"
+                      ></ButtonWithArrowDark>
+                    </ConcertEmptyButton>
+                  )}
                 </S.EmptyWrapper>
               </S.EmptyContainer>
             )}
           </S.MyreviewContainer>
-
           <Footer />
         </S.Section>
       </S.Main>


### PR DESCRIPTION
## 개요

다른 아티스트 페이지에서 공연등록 페이지로 이어지는 버튼 삭제

## 기능 구현

- 방문한 아티스트 페이지의 아티스트와 현재 접속한 유저의 정보가 다른 경우 공연 등록 버튼이 노출되지 않도록 수정
