### PR TITLE
Feat: 공연 정보 페이지 후기 표시 추가

### DIFF
--- a/client/src/pages/performance/performance-info/PerformanceInfo.style.ts
+++ b/client/src/pages/performance/performance-info/PerformanceInfo.style.ts
@@ -144,3 +144,35 @@ export const BottomStickyContainer = styled.div`
       bottom: calc(70px * ${screenScale.tablet});
   `}
 `;
+
+export const EmptyWrapper = styled.div`
+  width: 360px;
+  height: 100px;
+  background-color: var(--font-mid-color);
+  border-radius: 30px;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  margin-bottom: 10px;
+  ${DeviceQuery.tablet`
+      width: calc(360px * ${screenScale.tablet});
+      height: calc(100px * ${screenScale.tablet});
+      margin-bottom: calc(10px * ${screenScale.tablet});
+   `}
+`;
+export const EmptyTitle = styled.p`
+  ${FontStyle.smallRegular};
+  color: var(--font-highlight-color);
+  padding: 0px 15px 10px 15px;
+  ${DeviceQuery.tablet`
+      padding: calc(0px * ${screenScale.tablet}) calc(15px * ${screenScale.tablet}) calc(10px * ${screenScale.tablet}) calc(15px * ${screenScale.tablet});
+   `}
+`;
+
+// margin 되돌리기 용도
+export const ReviewDiv = styled.div`
+  margin-left: -15px;
+  ${DeviceQuery.tablet`
+    margin-left: calc(-15px * ${screenScale.tablet});
+  `}
+`;

--- a/client/src/pages/performance/performance-info/PerformanceInfo.tsx
+++ b/client/src/pages/performance/performance-info/PerformanceInfo.tsx
@@ -15,6 +15,7 @@ import { PerformanceType } from '../../../model/Performance';
 import { deletePerformance } from '../../../api/fetchAPI';
 import ReviewRegister from '../../../components/modal/review-register/ReviewRegister';
 import {
+  useGetArtistReview,
   useGetMemberPerformanced,
   useGetReservations,
 } from '../../../api/useFetch';
@@ -37,9 +38,11 @@ const PerformanceInfo = ({
   const [isTicketModalOpen, setIsReservationModalOpen] = useState(false);
   const [isReviewModalOpen, setIsReviewModalOpen] = useState(false);
   const [isReservationTicketOpen, setIsReservationTicketOpen] = useState(false);
-  // const performance = useGetPerformance(performanceId);
   const { performanceId } = useParams();
   const [isReserved, setIsReserved] = useState(false);
+  const artistReviews = useGetArtistReview(
+    Object.values(performance?.performanceArtist?.performanceArtistList)[0]
+  );
   useEffect(() => {
     if (reservations && performanceId) {
       setIsReserved(
@@ -223,6 +226,20 @@ const PerformanceInfo = ({
             setIsReservationTicketOpen(false);
           }}
         />
+      )}
+      <S.Heading3>아티스트의 공연 후기</S.Heading3>
+      {artistReviews?.length ? (
+        artistReviews.map(artistReview => {
+          return (
+            <S.ReviewDiv key={artistReview.reviewId}>
+              <Review {...artistReview} />
+            </S.ReviewDiv>
+          );
+        })
+      ) : (
+        <S.EmptyWrapper>
+          <S.EmptyTitle>완료한 공연이 없습니다.</S.EmptyTitle>
+        </S.EmptyWrapper>
       )}
     </>
   );


### PR DESCRIPTION
## 개요

공연 정보 페이지에 아티스트가 이전에 했던 공연의 후기를 표시합니다.

![image](https://github.com/codestates-seb/seb44_main_025/assets/83588163/1095e182-9279-453d-9384-d43a1ab2d43d)

![image](https://github.com/codestates-seb/seb44_main_025/assets/83588163/bfc4f0bc-f412-4cec-bfc3-ce11afd4e004)

## 부가 정보

- 어떤 공연에 해당하는 후기인지는 확인할 수 없네요. 세상에...

- 공연 상세 정보 페이지 이슈를 닫기 위한 마지막 피스